### PR TITLE
Improve gradient builder security and validation

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,20 +2,13 @@
 (function() {
     'use strict';
 
+    const GRADIENT_TYPES = new Set(['linear', 'radial', 'conic']);
+    const HEX_COLOR_REGEX = /^#(?:[0-9a-f]{3}){1,2}$/i;
+
     // ===================================================================
     // CONFIGURATION AND STATE
     // ===================================================================
-    const gradient = {
-        type: 'linear', 
-        angle: 90, 
-        shape: 'ellipse',
-        stops: [
-            { color: '#2b8efb', pos: 0 }, 
-            { color: '#1fc8a1', pos: 100 }
-        ],
-        blur: 0, 
-        noise: 0
-    };
+    const gradient = createDefaultGradientState();
     
     let presets = [];
     let activeStopIndex = 0;
@@ -115,34 +108,41 @@
     // UI RENDERING & UPDATES
     // ===================================================================
     function updatePreview() {
-        const css = generateGradientCSS(gradient);
+        const safeGradient = sanitizeGradientState(gradient);
+        const css = generateGradientCSS(safeGradient);
         const bgValue = css.replace('background: ', '').slice(0, -1);
-        
+
         els.previewEl.style.setProperty('--preview-bg', bgValue);
-        els.previewEl.style.setProperty('--preview-filter', `blur(${gradient.blur}px)`);
-        els.previewEl.style.setProperty('--preview-noise-opacity', gradient.noise / 100);
-        
+        els.previewEl.style.setProperty('--preview-filter', `blur(${safeGradient.blur}px)`);
+        els.previewEl.style.setProperty('--preview-noise-opacity', safeGradient.noise / 100);
+
         els.cssOutputEl.textContent = css;
-        ensureReadableTextColorOnPreview();
+        ensureReadableTextColorOnPreview(safeGradient);
     }
 
     function syncUIFromState() {
+        applySanitizedState(gradient, gradient);
+        if (!Number.isInteger(activeStopIndex) || activeStopIndex < 0) {
+            activeStopIndex = 0;
+        }
+        activeStopIndex = Math.min(activeStopIndex, gradient.stops.length - 1);
+
         // Update type tabs
         els.typeTabs.querySelectorAll('.tab-btn').forEach(btn => {
             btn.classList.toggle('active', btn.id === `type-${gradient.type}`);
         });
-        
+
         // Update angle controls
         els.angleControlGroup.style.display = gradient.type === 'radial' ? 'none' : 'block';
         els.angleSlider.value = gradient.angle;
         els.angleInput.value = gradient.angle;
-        
+
         // Update effect controls
         els.blurSlider.value = gradient.blur;
         els.blurInput.value = gradient.blur;
         els.noiseSlider.value = gradient.noise;
         els.noiseInput.value = gradient.noise;
-        
+
         renderStops();
     }
 
@@ -151,15 +151,48 @@
         gradient.stops.forEach((stop, index) => {
             const stopRow = document.createElement('div');
             stopRow.className = 'stop-row';
-            stopRow.classList.toggle('active', index === activeStopIndex);
-            stopRow.dataset.index = index;
-            stopRow.innerHTML = `
-                <input type="color" class="stop-color-input" data-index="${index}" value="${stop.color}">
-                <input type="text" class="stop-hex-input control-input" data-index="${index}" value="${stop.color}">
-                <input type="range" class="stop-pos-slider" data-index="${index}" min="0" max="100" value="${stop.pos}">
-                <span class="stop-pos-label">${stop.pos}%</span>
-                <button class="btn-remove-stop" data-index="${index}" aria-label="Remove stop ${index + 1}">&times;</button>
-            `;
+            stopRow.dataset.index = String(index);
+            if (index === activeStopIndex) {
+                stopRow.classList.add('active');
+            }
+
+            const colorInput = document.createElement('input');
+            colorInput.type = 'color';
+            colorInput.className = 'stop-color-input';
+            colorInput.dataset.index = String(index);
+            colorInput.value = stop.color;
+            colorInput.setAttribute('aria-label', `Color picker for stop ${index + 1}`);
+
+            const hexInput = document.createElement('input');
+            hexInput.type = 'text';
+            hexInput.className = 'stop-hex-input control-input';
+            hexInput.dataset.index = String(index);
+            hexInput.value = stop.color;
+            hexInput.setAttribute('maxlength', '7');
+            hexInput.setAttribute('spellcheck', 'false');
+            hexInput.setAttribute('autocomplete', 'off');
+            hexInput.setAttribute('aria-label', `Hex value for stop ${index + 1}`);
+
+            const slider = document.createElement('input');
+            slider.type = 'range';
+            slider.className = 'stop-pos-slider';
+            slider.dataset.index = String(index);
+            slider.min = '0';
+            slider.max = '100';
+            slider.value = stop.pos;
+
+            const label = document.createElement('span');
+            label.className = 'stop-pos-label';
+            label.textContent = `${stop.pos}%`;
+
+            const removeBtn = document.createElement('button');
+            removeBtn.className = 'btn-remove-stop';
+            removeBtn.dataset.index = String(index);
+            removeBtn.setAttribute('aria-label', `Remove stop ${index + 1}`);
+            removeBtn.type = 'button';
+            removeBtn.textContent = '×';
+
+            stopRow.append(colorInput, hexInput, slider, label, removeBtn);
             els.stopsContainer.appendChild(stopRow);
         });
     }
@@ -169,10 +202,16 @@
         presets.forEach((preset, index) => {
             const card = document.createElement('button');
             card.className = 'preset-card';
-            const css = generateGradientCSS(preset);
+            card.type = 'button';
+            const css = generateGradientCSS(sanitizeGradientState(preset));
             card.style.background = css.replace('background: ', '').slice(0, -1);
-            card.dataset.index = index;
-            card.innerHTML = `<span class="preset-name">${preset.name}</span>`;
+            card.dataset.index = String(index);
+
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'preset-name';
+            nameSpan.textContent = preset.name;
+            card.appendChild(nameSpan);
+
             els.presetsGrid.appendChild(card);
         });
     }
@@ -183,10 +222,15 @@
         
         els.paletteGrid.innerHTML = '';
         for (const [name, color] of Object.entries(palette)) {
+            const safeColor = sanitizeColor(color, null);
+            if (!safeColor) {
+                continue;
+            }
+
             const swatch = document.createElement('div');
             swatch.className = 'palette-swatch';
-            swatch.style.backgroundColor = color;
-            swatch.dataset.color = color;
+            swatch.style.backgroundColor = safeColor;
+            swatch.dataset.color = safeColor;
             swatch.dataset.tooltip = name;
             els.paletteGrid.appendChild(swatch);
         }
@@ -218,55 +262,96 @@
 
         // Type tabs
         els.typeTabs.addEventListener('click', e => {
-            if (e.target.matches('.tab-btn')) {
-                gradient.type = e.target.id.replace('type-', '');
-                activeStopIndex = 0;
-                syncUIFromState();
-                updatePreview();
-                saveState();
+            const tab = e.target.closest('.tab-btn');
+            if (!tab) {
+                return;
             }
+
+            const newType = tab.id.replace('type-', '');
+            if (!GRADIENT_TYPES.has(newType)) {
+                return;
+            }
+
+            gradient.type = newType;
+            if (newType !== 'radial') {
+                gradient.shape = 'ellipse';
+            }
+            activeStopIndex = 0;
+            syncUIFromState();
+            updatePreview();
+            saveState();
         });
 
         // Angle controls
         els.angleSlider.addEventListener('input', () => {
-            gradient.angle = els.angleSlider.value;
-            els.angleInput.value = els.angleSlider.value;
+            const value = clampNumber(els.angleSlider.value, 0, 360, gradient.angle);
+            gradient.angle = value;
+            const normalized = String(value);
+            els.angleSlider.value = normalized;
+            els.angleInput.value = normalized;
             updatePreview();
             debouncedSave();
         });
 
         els.angleInput.addEventListener('input', () => {
-            gradient.angle = els.angleInput.value;
-            els.angleSlider.value = els.angleInput.value;
+            const value = clampNumber(els.angleInput.value, 0, 360, null);
+            if (value === null) {
+                els.angleInput.value = String(gradient.angle);
+                return;
+            }
+            gradient.angle = value;
+            const normalized = String(value);
+            els.angleSlider.value = normalized;
+            els.angleInput.value = normalized;
             updatePreview();
             debouncedSave();
         });
 
         // Effect controls
         els.blurSlider.addEventListener('input', () => {
-            gradient.blur = els.blurSlider.value;
-            els.blurInput.value = els.blurSlider.value;
+            const value = clampNumber(els.blurSlider.value, 0, 40, gradient.blur);
+            gradient.blur = value;
+            const normalized = String(value);
+            els.blurSlider.value = normalized;
+            els.blurInput.value = normalized;
             updatePreview();
             debouncedSave();
         });
 
         els.blurInput.addEventListener('input', () => {
-            gradient.blur = els.blurInput.value;
-            els.blurSlider.value = els.blurInput.value;
+            const value = clampNumber(els.blurInput.value, 0, 40, null);
+            if (value === null) {
+                els.blurInput.value = String(gradient.blur);
+                return;
+            }
+            gradient.blur = value;
+            const normalized = String(value);
+            els.blurSlider.value = normalized;
+            els.blurInput.value = normalized;
             updatePreview();
             debouncedSave();
         });
 
         els.noiseSlider.addEventListener('input', () => {
-            gradient.noise = els.noiseSlider.value;
-            els.noiseInput.value = els.noiseSlider.value;
+            const value = clampNumber(els.noiseSlider.value, 0, 100, gradient.noise);
+            gradient.noise = value;
+            const normalized = String(value);
+            els.noiseSlider.value = normalized;
+            els.noiseInput.value = normalized;
             updatePreview();
             debouncedSave();
         });
 
         els.noiseInput.addEventListener('input', () => {
-            gradient.noise = els.noiseInput.value;
-            els.noiseSlider.value = els.noiseInput.value;
+            const value = clampNumber(els.noiseInput.value, 0, 100, null);
+            if (value === null) {
+                els.noiseInput.value = String(gradient.noise);
+                return;
+            }
+            gradient.noise = value;
+            const normalized = String(value);
+            els.noiseSlider.value = normalized;
+            els.noiseInput.value = normalized;
             updatePreview();
             debouncedSave();
         });
@@ -275,28 +360,61 @@
         els.addStopBtn.addEventListener('click', addStop);
 
         els.stopsContainer.addEventListener('input', e => {
-            const index = parseInt(e.target.dataset.index);
-            if (isNaN(index)) return;
-            
+            const target = e.target;
+            if (!target || !target.classList) {
+                return;
+            }
+
+            const index = Number.parseInt(target.dataset.index, 10);
+            if (!Number.isInteger(index) || !gradient.stops[index]) {
+                return;
+            }
+
             activeStopIndex = index;
-            
-            if (e.target.matches('.stop-color-input, .stop-hex-input')) {
-                gradient.stops[index].color = e.target.value;
-                
-                // Sync color and hex inputs
-                const colorInput = e.target.matches('.stop-color-input') ? 
-                    e.target : e.target.previousElementSibling;
-                const hexInput = e.target.matches('.stop-hex-input') ? 
-                    e.target : e.target.nextElementSibling;
-                    
-                colorInput.value = e.target.value;
-                hexInput.value = e.target.value;
-                
+            const parentRow = target.closest('.stop-row');
+
+            if (target.classList.contains('stop-color-input')) {
+                const sanitizedColor = sanitizeColor(target.value, gradient.stops[index].color);
+                gradient.stops[index].color = sanitizedColor;
+                if (parentRow) {
+                    const hexInput = parentRow.querySelector('.stop-hex-input');
+                    if (hexInput) {
+                        hexInput.value = sanitizedColor;
+                        hexInput.classList.remove('invalid');
+                        hexInput.removeAttribute('aria-invalid');
+                    }
+                }
                 updatePreview();
                 debouncedSave();
-            } else if (e.target.matches('.stop-pos-slider')) {
-                gradient.stops[index].pos = parseInt(e.target.value);
-                e.target.nextElementSibling.textContent = `${e.target.value}%`;
+            } else if (target.classList.contains('stop-hex-input')) {
+                const sanitizedHex = sanitizeColor(target.value, null);
+                if (!sanitizedHex) {
+                    target.classList.add('invalid');
+                    target.setAttribute('aria-invalid', 'true');
+                    return;
+                }
+                gradient.stops[index].color = sanitizedHex;
+                target.value = sanitizedHex;
+                target.classList.remove('invalid');
+                target.removeAttribute('aria-invalid');
+                if (parentRow) {
+                    const colorInput = parentRow.querySelector('.stop-color-input');
+                    if (colorInput) {
+                        colorInput.value = sanitizedHex;
+                    }
+                }
+                updatePreview();
+                debouncedSave();
+            } else if (target.classList.contains('stop-pos-slider')) {
+                const sanitizedPos = clampNumber(target.value, 0, 100, gradient.stops[index].pos);
+                gradient.stops[index].pos = sanitizedPos;
+                target.value = String(sanitizedPos);
+                if (parentRow) {
+                    const label = parentRow.querySelector('.stop-pos-label');
+                    if (label) {
+                        label.textContent = `${sanitizedPos}%`;
+                    }
+                }
                 updatePreview();
                 debouncedReorderRenderSave();
             }
@@ -304,10 +422,16 @@
 
         els.stopsContainer.addEventListener('click', e => {
             const row = e.target.closest('.stop-row');
-            if (!row) return;
-            
-            const index = parseInt(row.dataset.index);
-            if (e.target.matches('.btn-remove-stop')) {
+            if (!row) {
+                return;
+            }
+
+            const index = Number.parseInt(row.dataset.index, 10);
+            if (!Number.isInteger(index) || !gradient.stops[index]) {
+                return;
+            }
+
+            if (e.target.closest('.btn-remove-stop')) {
                 removeStop(index);
             } else if (activeStopIndex !== index) {
                 activeStopIndex = index;
@@ -321,40 +445,70 @@
         });
 
         els.paletteGrid.addEventListener('click', e => {
-            if (e.target.matches('.palette-swatch')) {
-                gradient.stops[activeStopIndex].color = e.target.dataset.color;
-                renderStops();
-                updatePreview();
-                saveState();
+            const swatch = e.target.closest('.palette-swatch');
+            if (!swatch || !gradient.stops.length) {
+                return;
             }
+
+            const color = sanitizeColor(swatch.dataset.color, null);
+            if (!color) {
+                return;
+            }
+
+            const index = Math.min(Math.max(activeStopIndex, 0), gradient.stops.length - 1);
+            gradient.stops[index].color = color;
+            renderStops();
+            updatePreview();
+            saveState();
         });
 
         // Presets
         els.presetsGrid.addEventListener('click', e => {
             const card = e.target.closest('.preset-card');
-            if (card) applyPreset(card.dataset.index);
+            if (!card) {
+                return;
+            }
+
+            const presetIndex = Number.parseInt(card.dataset.index, 10);
+            if (Number.isNaN(presetIndex)) {
+                return;
+            }
+
+            applyPreset(presetIndex);
         });
 
         // Action buttons
         els.randomizeBtn.addEventListener('click', randomizeGradient);
-        els.copyCssBtn.addEventListener('click', () => copyToClipboard(els.cssOutputEl.textContent));
+        els.copyCssBtn.addEventListener('click', () => copyToClipboard(els.cssOutputEl.textContent || ''));
         els.exportCssBtn.addEventListener('click', exportCssFile);
-        els.saveImageBtn.addEventListener('click', () => els.exportModal.showModal());
+        els.saveImageBtn.addEventListener('click', () => {
+            if (typeof els.exportModal.showModal === 'function') {
+                els.exportModal.showModal();
+            }
+        });
 
         // Modal
         els.closeModalBtn.addEventListener('click', () => els.exportModal.close());
         els.cancelExportBtn.addEventListener('click', () => els.exportModal.close());
         els.confirmExportBtn.addEventListener('click', () => {
-            const format = els.exportModal.querySelector('input[name="format"]:checked').value;
-            const resKey = els.exportModal.querySelector('input[name="resolution"]:checked').value;
-            const { width, height } = RESOLUTIONS[resKey];
-            
-            if (format === 'svg') {
-                exportAsSVG(width, height);
-            } else {
-                exportAsRaster(format, width, height);
+            const formatInput = els.exportModal.querySelector('input[name="format"]:checked');
+            const resolutionInput = els.exportModal.querySelector('input[name="resolution"]:checked');
+            if (!formatInput || !resolutionInput) {
+                return;
             }
-            
+
+            const format = formatInput.value;
+            const resolution = RESOLUTIONS[resolutionInput.value];
+            if (!resolution) {
+                return;
+            }
+
+            if (format === 'svg') {
+                exportAsSVG(resolution.width, resolution.height);
+            } else if (format === 'png' || format === 'jpg') {
+                exportAsRaster(format, resolution.width, resolution.height);
+            }
+
             els.exportModal.close();
         });
     }
@@ -364,88 +518,111 @@
     // ===================================================================
     function saveState() {
         try {
-            localStorage.setItem('gradient-state', JSON.stringify(gradient));
+            const safeGradient = sanitizeGradientState(gradient);
+            localStorage.setItem('gradient-state', JSON.stringify(safeGradient));
         } catch (e) {
-            console.error("Error saving state:", e);
+            console.error('Error saving state:', e);
         }
     }
 
     function loadState() {
         const saved = localStorage.getItem('gradient-state');
-        if (saved) {
-            try {
-                const parsed = JSON.parse(saved);
-                if (parsed && parsed.stops) {
-                    Object.assign(gradient, parsed);
-                }
-            } catch (e) {
-                console.error("Error loading state:", e);
-            }
+        if (!saved) {
+            return;
+        }
+
+        try {
+            const parsed = JSON.parse(saved);
+            applySanitizedState(gradient, parsed);
+            activeStopIndex = Math.min(activeStopIndex, gradient.stops.length - 1);
+        } catch (e) {
+            console.error('Error loading state:', e);
         }
     }
 
     function applyPreset(index) {
-        const preset = JSON.parse(JSON.stringify(presets[index]));
-        if (preset) {
-            gradient.type = preset.type || 'linear';
-            gradient.angle = preset.angle || 90;
-            gradient.shape = preset.shape || 'ellipse';
-            gradient.stops = preset.stops || [];
-            gradient.blur = 0;
-            gradient.noise = 0;
-            activeStopIndex = 0;
-            syncUIFromState();
-            updatePreview();
-            saveState();
+        const preset = presets[index];
+        if (!preset) {
+            return;
         }
-    }
 
-    function randomizeGradient() {
-        gradient.type = ['linear', 'radial', 'conic'][Math.floor(Math.random() * 3)];
-        gradient.angle = Math.floor(Math.random() * 361);
-        
-        const count = Math.floor(Math.random() * 3) + 3;
-        gradient.stops = Array.from({ length: count }, (_, i) => ({
-            color: '#' + Math.floor(Math.random() * 16777215).toString(16).padStart(6, '0'),
-            pos: Math.round((i / (count - 1)) * 100)
-        }));
-        
-        gradient.blur = 0;
-        gradient.noise = 0;
+        applySanitizedState(gradient, {
+            ...preset,
+            blur: 0,
+            noise: 0
+        });
         activeStopIndex = 0;
-        
         syncUIFromState();
         updatePreview();
         saveState();
-        showToast("Gradient Randomized!");
+    }
+
+    function randomizeGradient() {
+        const types = Array.from(GRADIENT_TYPES);
+        const randomType = types[Math.floor(Math.random() * types.length)] || 'linear';
+        const count = Math.floor(Math.random() * 3) + 3;
+        const stops = Array.from({ length: count }, (_, i) => ({
+            color: `#${Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0').toUpperCase()}`,
+            pos: Math.round((i / Math.max(count - 1, 1)) * 100)
+        }));
+
+        applySanitizedState(gradient, {
+            type: randomType,
+            angle: Math.floor(Math.random() * 361),
+            shape: 'ellipse',
+            stops,
+            blur: 0,
+            noise: 0
+        });
+        activeStopIndex = 0;
+
+        syncUIFromState();
+        updatePreview();
+        saveState();
+        showToast('Gradient Randomized!');
     }
 
     function addStop() {
-        gradient.stops.push({ color: '#ffffff', pos: 50 });
+        const newStop = { color: '#FFFFFF', pos: 50 };
+        gradient.stops.push(newStop);
         reorderStops();
-        activeStopIndex = gradient.stops.length - 1;
+        activeStopIndex = gradient.stops.indexOf(newStop);
+        if (activeStopIndex === -1) {
+            activeStopIndex = gradient.stops.length - 1;
+        }
         renderStops();
         updatePreview();
         saveState();
     }
 
     function removeStop(index) {
-        if (gradient.stops.length <= 2) {
-            showToast("Minimum of 2 stops is required.");
+        if (!Number.isInteger(index) || index < 0 || index >= gradient.stops.length) {
             return;
         }
-        
-        gradient.stops.splice(index, 1);
-        if (activeStopIndex >= index) {
-            activeStopIndex = Math.max(0, activeStopIndex - 1);
+
+        if (gradient.stops.length <= 2) {
+            showToast('Minimum of 2 stops is required.');
+            return;
         }
-        
+
+        gradient.stops.splice(index, 1);
+        if (activeStopIndex >= gradient.stops.length) {
+            activeStopIndex = gradient.stops.length - 1;
+        } else if (activeStopIndex > index) {
+            activeStopIndex -= 1;
+        }
+        activeStopIndex = Math.max(0, activeStopIndex);
+
         renderStops();
         updatePreview();
         saveState();
     }
 
     function reorderStops() {
+        gradient.stops.forEach(stop => {
+            stop.color = sanitizeColor(stop.color, '#FFFFFF') || '#FFFFFF';
+            stop.pos = clampNumber(stop.pos, 0, 100, 0);
+        });
         gradient.stops.sort((a, b) => a.pos - b.pos);
     }
 
@@ -453,36 +630,40 @@
     // GENERATION & EXPORT
     // ===================================================================
     function generateGradientCSS(g) {
-        const stopsStr = g.stops.map(s => `${s.color} ${s.pos}%`).join(', ');
-        
-        switch (g.type) {
+        const safeGradient = sanitizeGradientState(g);
+        const stopsStr = safeGradient.stops.map(s => `${s.color} ${s.pos}%`).join(', ');
+
+        switch (safeGradient.type) {
             case 'radial':
-                return `background: radial-gradient(${g.shape}, ${stopsStr});`;
+                return `background: radial-gradient(${safeGradient.shape}, ${stopsStr});`;
             case 'conic':
-                return `background: conic-gradient(from ${g.angle}deg, ${stopsStr});`;
+                return `background: conic-gradient(from ${safeGradient.angle}deg, ${stopsStr});`;
             default:
-                return `background: linear-gradient(${g.angle}deg, ${stopsStr});`;
+                return `background: linear-gradient(${safeGradient.angle}deg, ${stopsStr});`;
         }
     }
 
     function generateSVGString(g, w, h) {
-        const stopsSVG = g.stops.map(s => 
+        const safeGradient = sanitizeGradientState(g);
+        const widthValue = toSafeDimension(w, 1920);
+        const heightValue = toSafeDimension(h, 1080);
+        const stopsSVG = safeGradient.stops.map(s =>
             `<stop offset="${s.pos}%" stop-color="${s.color}" />`
         ).join('');
-        
+
         let gradientTag;
-        if (g.type === 'linear') {
-            gradientTag = `<linearGradient id="g" gradientTransform="rotate(${g.angle - 90})">${stopsSVG}</linearGradient>`;
-        } else if (g.type === 'radial') {
+        if (safeGradient.type === 'linear') {
+            gradientTag = `<linearGradient id="g" gradientTransform="rotate(${safeGradient.angle - 90})">${stopsSVG}</linearGradient>`;
+        } else if (safeGradient.type === 'radial') {
             gradientTag = `<radialGradient id="g" cx="50%" cy="50%" r="50%">${stopsSVG}</radialGradient>`;
         } else {
             // Conic gradient approximation for SVG
             gradientTag = `<linearGradient id="g">${stopsSVG}</linearGradient>`;
         }
-        
-        return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
+
+        return `<svg xmlns="http://www.w3.org/2000/svg" width="${widthValue}" height="${heightValue}" viewBox="0 0 ${widthValue} ${heightValue}">
             <defs>${gradientTag}</defs>
-            <rect width="${w}" height="${h}" fill="url(#g)" />
+            <rect width="${widthValue}" height="${heightValue}" fill="url(#g)" />
         </svg>`;
     }
 
@@ -490,72 +671,97 @@
         const svgString = generateSVGString(gradient, width, height);
         const blob = new Blob([svgString], { type: 'image/svg+xml' });
         const url = URL.createObjectURL(blob);
-        
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'gradient.svg';
-        a.click();
-        
+
+        triggerDownload(url, 'gradient.svg');
         URL.revokeObjectURL(url);
         showToast('Image exported as SVG!');
     }
 
     function exportAsRaster(format, width, height) {
-        const svgString = generateSVGString(gradient, width, height);
+        const safeFormat = format === 'jpg' ? 'jpg' : 'png';
+        const safeGradient = sanitizeGradientState(gradient);
+        const widthValue = toSafeDimension(width, RESOLUTIONS['1080p'].width);
+        const heightValue = toSafeDimension(height, RESOLUTIONS['1080p'].height);
+        const svgString = generateSVGString(safeGradient, widthValue, heightValue);
         const blob = new Blob([svgString], { type: 'image/svg+xml' });
         const url = URL.createObjectURL(blob);
-        
+
         const canvas = document.createElement('canvas');
-        canvas.width = width;
-        canvas.height = height;
+        canvas.width = widthValue;
+        canvas.height = heightValue;
         const ctx = canvas.getContext('2d');
-        
-        const img = new Image();
-        img.onload = () => {
-            // Apply blur if needed
-            if (gradient.blur > 0) {
-                ctx.filter = `blur(${gradient.blur}px)`;
-            }
-            
-            ctx.drawImage(img, 0, 0, width, height);
-            ctx.filter = 'none';
-            
+        if (!ctx) {
             URL.revokeObjectURL(url);
-            
-            // Apply noise if needed
-            if (gradient.noise > 0) {
-                drawNoise(ctx, width, height, gradient.noise);
+            showToast('Canvas not supported in this browser.');
+            return;
+        }
+
+        const img = new Image();
+        img.decoding = 'async';
+        img.onload = () => {
+            if (safeGradient.blur > 0) {
+                ctx.filter = `blur(${safeGradient.blur}px)`;
             }
-            
-            // Convert to desired format
-            canvas.toBlob(blob => {
-                const dataUrl = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = dataUrl;
-                a.download = `gradient.${format}`;
-                a.click();
-                URL.revokeObjectURL(dataUrl);
-                showToast(`Image exported as ${format.toUpperCase()}!`);
-            }, `image/${format}`, format === 'jpg' ? 0.9 : 1.0);
+
+            ctx.drawImage(img, 0, 0, widthValue, heightValue);
+            ctx.filter = 'none';
+
+            URL.revokeObjectURL(url);
+
+            if (safeGradient.noise > 0) {
+                drawNoise(ctx, widthValue, heightValue, safeGradient.noise);
+            }
+
+            const mime = safeFormat === 'jpg' ? 'image/jpeg' : 'image/png';
+            const quality = safeFormat === 'jpg' ? 0.9 : 1.0;
+
+            const finalizeDownload = (data, isObjectUrl) => {
+                triggerDownload(data, `gradient.${safeFormat}`);
+                if (isObjectUrl) {
+                    URL.revokeObjectURL(data);
+                }
+                showToast(`Image exported as ${safeFormat.toUpperCase()}!`);
+            };
+
+            if (canvas.toBlob) {
+                canvas.toBlob(result => {
+                    if (result) {
+                        const objectUrl = URL.createObjectURL(result);
+                        finalizeDownload(objectUrl, true);
+                    } else {
+                        finalizeDownload(canvas.toDataURL(mime, quality), false);
+                    }
+                }, mime, quality);
+            } else {
+                finalizeDownload(canvas.toDataURL(mime, quality), false);
+            }
         };
-        
+
         img.onerror = () => {
             URL.revokeObjectURL(url);
-            showToast("Error creating image.");
+            showToast('Error creating image.');
         };
-        
+
         img.src = url;
     }
 
     function drawNoise(ctx, w, h, opacity) {
+        const safeOpacity = clampNumber(opacity, 0, 100, 0);
+        if (safeOpacity <= 0) {
+            return;
+        }
+
         const noiseCanvas = document.createElement('canvas');
         noiseCanvas.width = 100;
         noiseCanvas.height = 100;
         const noiseCtx = noiseCanvas.getContext('2d');
-        
+        if (!noiseCtx) {
+            return;
+        }
+
         const imageData = noiseCtx.createImageData(100, 100);
         const data = imageData.data;
-        
+
         for (let i = 0; i < data.length; i += 4) {
             const val = Math.floor(Math.random() * 255);
             data[i] = val;
@@ -563,34 +769,56 @@
             data[i + 2] = val;
             data[i + 3] = 255;
         }
-        
+
         noiseCtx.putImageData(imageData, 0, 0);
-        
-        ctx.globalAlpha = opacity / 100;
-        ctx.fillStyle = ctx.createPattern(noiseCanvas, 'repeat');
+
+        const pattern = ctx.createPattern(noiseCanvas, 'repeat');
+        if (!pattern) {
+            return;
+        }
+
+        ctx.save();
+        ctx.globalAlpha = safeOpacity / 100;
+        ctx.fillStyle = pattern;
         ctx.fillRect(0, 0, w, h);
-        ctx.globalAlpha = 1.0;
+        ctx.restore();
     }
 
     async function copyToClipboard(text) {
+        const safeText = typeof text === 'string' ? text : '';
+        if (!safeText) {
+            showToast('Nothing to copy.');
+            return;
+        }
+
         try {
-            await navigator.clipboard.writeText(text);
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(safeText);
+            } else {
+                const textarea = document.createElement('textarea');
+                textarea.value = safeText;
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'absolute';
+                textarea.style.left = '-9999px';
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textarea);
+            }
             showToast('CSS copied!');
         } catch (err) {
+            console.error('Clipboard error:', err);
             showToast('Failed to copy.');
         }
     }
 
     function exportCssFile() {
-        const content = `.generated-gradient {\n    ${generateGradientCSS(gradient)}\n}`;
+        const safeGradient = sanitizeGradientState(gradient);
+        const content = `.generated-gradient {\n    ${generateGradientCSS(safeGradient)}\n}`;
         const blob = new Blob([content], { type: 'text/css' });
         const url = URL.createObjectURL(blob);
-        
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = 'gradient.css';
-        a.click();
-        
+
+        triggerDownload(url, 'gradient.css');
         URL.revokeObjectURL(url);
         showToast('CSS file exported!');
     }
@@ -607,7 +835,7 @@
     }
 
     function getDefaultPresets() {
-        return [
+        const presetsList = [
             {
                 name: 'Ocean Blue',
                 type: 'linear',
@@ -651,8 +879,8 @@
                 type: 'conic',
                 angle: 180,
                 stops: [
-                    { color: '#a1c4fd', pos: 0 },
-                    { color: '#c2e9fb', pos: 100 }
+                    { color: '#A1C4FD', pos: 0 },
+                    { color: '#C2E9FB', pos: 100 }
                 ]
             },
             {
@@ -666,15 +894,31 @@
                 ]
             }
         ];
+
+        return presetsList.map(preset => sanitizeGradientState(preset));
     }
 
-    function ensureReadableTextColorOnPreview() {
-        const midStop = gradient.stops[Math.floor(gradient.stops.length / 2)];
-        if (!midStop) return;
-        
-        const bgColor = hexToRgb(midStop.color);
-        if (!bgColor) return;
-        
+    function ensureReadableTextColorOnPreview(currentGradient = gradient) {
+        if (!currentGradient || !Array.isArray(currentGradient.stops) || !currentGradient.stops.length) {
+            return;
+        }
+
+        const stops = currentGradient.stops;
+        const midStop = stops[Math.floor(stops.length / 2)];
+        if (!midStop) {
+            return;
+        }
+
+        const sanitizedColor = sanitizeColor(midStop.color, null);
+        if (!sanitizedColor) {
+            return;
+        }
+
+        const bgColor = hexToRgb(sanitizedColor);
+        if (!bgColor) {
+            return;
+        }
+
         const lum = relativeLuminance(bgColor);
         els.previewLabel.style.color = (lum > 0.4) ? '#000000' : '#FFFFFF';
     }
@@ -694,6 +938,144 @@
             return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
         });
         return a[0] * 0.2126 + a[1] * 0.7152 + a[2] * 0.0722;
+    }
+
+    // ===================================================================
+    // SANITIZATION & DOWNLOAD HELPERS
+    // ===================================================================
+    function createDefaultGradientState() {
+        return {
+            type: 'linear',
+            angle: 90,
+            shape: 'ellipse',
+            stops: [
+                { color: '#2B8EFB', pos: 0 },
+                { color: '#1FC8A1', pos: 100 }
+            ],
+            blur: 0,
+            noise: 0
+        };
+    }
+
+    function normalizeHex(value) {
+        if (typeof value !== 'string') {
+            return null;
+        }
+
+        let normalized = value.trim();
+        if (!normalized) {
+            return null;
+        }
+
+        if (!normalized.startsWith('#')) {
+            normalized = `#${normalized}`;
+        }
+
+        if (!HEX_COLOR_REGEX.test(normalized)) {
+            return null;
+        }
+
+        if (normalized.length === 4) {
+            normalized = `#${normalized[1]}${normalized[1]}${normalized[2]}${normalized[2]}${normalized[3]}${normalized[3]}`;
+        }
+
+        return normalized.toUpperCase();
+    }
+
+    function sanitizeColor(value, fallback = null) {
+        return normalizeHex(value) ?? normalizeHex(fallback);
+    }
+
+    function clampNumber(value, min, max, fallback = null) {
+        if (typeof value === 'string' && value.trim() === '') {
+            return fallback;
+        }
+
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+            return fallback;
+        }
+
+        const clamped = Math.min(max, Math.max(min, num));
+        return Math.round(clamped);
+    }
+
+    function sanitizeStop(stop, fallbackStop) {
+        const baseStop = fallbackStop || { color: '#FFFFFF', pos: 0 };
+        if (!stop || typeof stop !== 'object') {
+            return { color: baseStop.color, pos: baseStop.pos };
+        }
+
+        const color = sanitizeColor(stop.color, baseStop.color) || baseStop.color;
+        const pos = clampNumber(stop.pos, 0, 100, baseStop.pos);
+        return { color, pos };
+    }
+
+    function sanitizeGradientState(state) {
+        const base = createDefaultGradientState();
+        if (!state || typeof state !== 'object') {
+            return createDefaultGradientState();
+        }
+
+        const sanitized = {
+            type: GRADIENT_TYPES.has(state.type) ? state.type : base.type,
+            angle: clampNumber(state.angle, 0, 360, base.angle),
+            shape: base.shape,
+            stops: [],
+            blur: clampNumber(state.blur, 0, 40, base.blur),
+            noise: clampNumber(state.noise, 0, 100, base.noise)
+        };
+
+        if (sanitized.type === 'radial' && state.shape === 'circle') {
+            sanitized.shape = 'circle';
+        }
+
+        const stopsSource = Array.isArray(state.stops) ? state.stops : [];
+        sanitized.stops = stopsSource
+            .map((stop, index) => sanitizeStop(stop, base.stops[index % base.stops.length]))
+            .filter(Boolean);
+
+        if (sanitized.stops.length < 2) {
+            sanitized.stops = base.stops.map(stop => ({ ...stop }));
+        }
+
+        sanitized.stops.sort((a, b) => a.pos - b.pos);
+
+        return sanitized;
+    }
+
+    function applySanitizedState(target, rawState) {
+        const sanitized = sanitizeGradientState(rawState);
+        target.type = sanitized.type;
+        target.angle = sanitized.angle;
+        target.shape = sanitized.shape;
+        target.stops = sanitized.stops.map(stop => ({ ...stop }));
+        target.blur = sanitized.blur;
+        target.noise = sanitized.noise;
+        return target;
+    }
+
+    function toSafeDimension(value, fallback) {
+        const num = Number(value);
+        if (Number.isFinite(num) && num > 0) {
+            return Math.min(10000, Math.round(num));
+        }
+        const fallbackNum = Number(fallback);
+        if (Number.isFinite(fallbackNum) && fallbackNum > 0) {
+            return Math.min(10000, Math.round(fallbackNum));
+        }
+        return 1000;
+    }
+
+    function triggerDownload(url, filename) {
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = filename;
+        anchor.rel = 'noopener noreferrer';
+        anchor.style.display = 'none';
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
     }
 
     // Initialize when DOM is ready

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gradient Studio Pro</title>
+    <title>Gradient Studio By Malek</title>
     <link rel="stylesheet" href="styles.css">
     <script src="app.js" defer></script>
 </head>
@@ -29,7 +29,7 @@
             <header class="main-header glass-panel">
                 <div class="logo">
                     <div class="logo-icon">🎨</div>
-                    <h1>Gradient Studio Pro</h1>
+                    <h1>Gradient Studio By Malek</h1>
                 </div>
                 <nav class="gradient-type-tabs" role="tablist" aria-label="Gradient type">
                     <button role="tab" aria-selected="true" id="type-linear" class="tab-btn active"><span>Linear</span></button>

--- a/styles.css
+++ b/styles.css
@@ -499,6 +499,17 @@ input[type="range"]::-moz-range-thumb {
     box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
 }
 
+.control-input.invalid,
+.control-input[aria-invalid="true"] {
+    border-color: var(--danger);
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+}
+
+.control-input.invalid:focus,
+.control-input[aria-invalid="true"]:focus {
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.3);
+}
+
 input[type="number"] {
     width: 80px;
 }


### PR DESCRIPTION
## Summary
- sanitize gradient state handling, rebuild stop rendering without innerHTML, and validate palette usage to avoid injection
- validate numeric inputs, randomization, and storage to keep gradient data within safe ranges while updating UI controls
- harden export and clipboard utilities with safe downloads and graceful fallbacks, plus flag invalid inputs visually in CSS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c882ddcb98832faf60c0b29c951dfd